### PR TITLE
Move options as an compat-layer argument

### DIFF
--- a/src/amp-react-carousel.js
+++ b/src/amp-react-carousel.js
@@ -23,26 +23,6 @@ import ReactCompatibleBaseElement from './react-compat-base-element.js';
 class AmpCarousel extends React.Component {
 
   /**
-   * @return {!Object}
-   */
-  static opts() {
-    return {
-      attrs: {
-        'current-slide': {
-          prop: 'currentSlide',
-          type: 'number',
-        },
-      },
-      children: {
-        'arrowNext': '[arrow-next]',
-        'arrowPrev': '[arrow-prev]',
-        'children': '*',
-      },
-      shadow: true,
-    };
-  }
-
-  /**
    * @param {!Object} props
    */
   constructor(props) {
@@ -229,5 +209,17 @@ class AmpCarousel extends React.Component {
   }
 }
 
-const AmpReactCarousel = ReactCompatibleBaseElement(AmpCarousel);
+const AmpReactCarousel = ReactCompatibleBaseElement(AmpCarousel, {
+  attrs: {
+    'current-slide': {
+      prop: 'currentSlide',
+      type: 'number',
+    },
+  },
+  children: {
+    'arrowNext': '[arrow-next]',
+    'arrowPrev': '[arrow-prev]',
+    'children': '*',
+  },
+});
 customElements.define('amp-react-carousel', AmpReactCarousel);

--- a/src/amp-react-img.js
+++ b/src/amp-react-img.js
@@ -172,5 +172,5 @@ function addToClass(classes, add) {
   return (classes || '') + ' ' + add;
 }
 
-const AmpReactImg = ReactCompatibleBaseElement(AmpImg);
+const AmpReactImg = ReactCompatibleBaseElement(AmpImg, {});
 customElements.define('amp-react-img', AmpReactImg);

--- a/src/react-compat-base-element.js
+++ b/src/react-compat-base-element.js
@@ -30,16 +30,17 @@ import devAssert from './dev-assert.js';
  * provide compatibilty between CE and React.
  *
  * @param {!React.Component} Component
+ * @param {!AmpElementOptions} opts
  * @return {Amp.BaseElement}
  */
-export default function ReactCompatibleBaseElement(Component) {
+export default function ReactCompatibleBaseElement(Component, opts) {
   class ReactBaseElement {
 
     /**
      * @return {?Object|undefined}
      */
     static opts() {
-      return Component.opts && Component.opts();
+      return opts;
     }
 
     /** @param {!AmpElement} element */
@@ -114,8 +115,6 @@ export default function ReactCompatibleBaseElement(Component) {
 
     /** @private */
     rerender_() {
-      const opts = ReactBaseElement.opts() || {};
-
       if (!this.container_) {
         // TBD: create container/shadow in the amp-element.js?
         if (opts.children) {
@@ -438,6 +437,11 @@ export default function ReactCompatibleBaseElement(Component) {
 }
 
 
+/**
+ * @param {!Element} element
+ * @param {!AmpElementOptions} opts
+ * @return {!Object}
+ */
 function collectProps(element, opts) {
   const defs = opts.attrs || {};
   const props = {};
@@ -502,6 +506,10 @@ function matchChild(element, defs) {
   return null;
 }
 
+/**
+ * @param {!Element} element
+ * @return {!Object}
+ */
 function collectStyle(element) {
   const { style } = element;
   const styleMap = {};


### PR DESCRIPTION
This makes more sense to me because `opts` is a compatibility argument - it does not do anything for the React component itself - only used to map a custom element environment to the React component. This also addresses the question of whether it should be a static value or a function.