### PR TITLE
amp-selector implementation in React

### DIFF
--- a/index-react.html
+++ b/index-react.html
@@ -19,6 +19,7 @@
     import {AmpImg} from './src/amp-react-img.js';
     import {AmpLayout} from './src/amp-react-layout.js';
     import {AmpLightbox} from './src/amp-react-lightbox.js';
+    import {AmpSelector} from './src/amp-react-selector.js';
     import {AmpSize} from './src/amp-react-size.js';
     import {AmpYoutube} from './src/amp-react-youtube.js';
     Object.assign(window, {
@@ -27,10 +28,16 @@
       AmpFitText,
       AmpLayout,
       AmpLightbox,
+      AmpSelector,
       AmpSize,
       AmpYoutube,
     });
   </script>
+  <style>
+    li[selected] {
+      font-weight: bold;
+    }
+  </style>
 </head>
 <body>
 
@@ -46,6 +53,7 @@ class App extends preact.Component {
   state = {
     slides: [0, 1, 2, 3, 4, 5],
     lightbox1Open: false,
+    selector1Value: '1',
   };
 
   constructor(props) {
@@ -183,6 +191,33 @@ class App extends preact.Component {
             Can you fit this text?
           </AmpFitText>
         </AmpLayout>
+
+        <AmpSelector style={{width: '100%', height: '80px', border: '1px dotted lightgray'}}
+            value={this.state.selector1Value}
+            onChange={event => this.setState({selector1Value: event.target.value})}>
+          <ul>
+            <AmpSelector.Option
+                // TBD: style 1: tagName+content.
+                option="1"
+                tagName="li"
+                >
+              Option 1
+            </AmpSelector.Option>
+            <AmpSelector.Option
+                // TBD: style 2: render-function.
+                option="2"
+                render={props => (
+                  <li {...props}>Option 2</li>
+                )}>
+            </AmpSelector.Option>
+            <AmpSelector.Option
+                option="3"
+                render={props => (
+                  <li {...props}>Option 3</li>
+                )}>
+            </AmpSelector.Option>
+          </ul>
+        </AmpSelector>
 
         <div style={{height: '500vh'}}>scroll down...</div>
         <AmpImg

--- a/index-react.html
+++ b/index-react.html
@@ -218,6 +218,9 @@ class App extends preact.Component {
             </AmpSelector.Option>
           </ul>
         </AmpSelector>
+        <div>
+          <button onClick={() => this.setState({selector1Value: '2'})}>Select option 2</button>
+        </div>
 
         <div style={{height: '500vh'}}>scroll down...</div>
         <AmpImg

--- a/index.html
+++ b/index.html
@@ -204,6 +204,16 @@
           }
         });
       }
+      function selectOption(option) {
+        const optionElements = selector1.querySelectorAll(':scope > ul > li');
+        optionElements.forEach(optionElement => {
+          if (optionElement.getAttribute('option') == option) {
+            optionElement.setAttribute('selected', '');
+          } else {
+            optionElement.removeAttribute('selected');
+          }
+        });
+      }
     </script>
   </head>
   <body>
@@ -346,6 +356,9 @@
         <li option="3">Option 3</li>
       </ul>
     </amp-react-selector>
+    <div>
+      <button onclick="selectOption('2')">Select option 2</button>
+    </div>
 
     <div style="height: 500vh">scroll down...</div>
 

--- a/index.html
+++ b/index.html
@@ -182,6 +182,12 @@
     <script type="module" src="./src/amp-react-youtube.js"></script>
     <script type="module" src="./src/amp-react-unload-outside-viewport.js"></script>
     <script type="module" src="./src/amp-react-fit-text.js"></script>
+    <script type="module" src="./src/amp-react-selector.js"></script>
+    <style>
+      li[selected] {
+        font-weight: bold;
+      }
+    </style>
     <script>
       function addSlide() {
         [c1, c2].forEach(function(carousel) {
@@ -329,6 +335,17 @@
       style="border: 1px dotted lightgray;">
       Can you fit this text?
     </amp-fit-text>
+
+    <amp-react-selector
+      id="selector1"
+      layout="container"
+      style="border: 1px dotted lightgray;">
+      <ul>
+        <li option="1" selected>Option 1</li>
+        <li option="2">Option 2</li>
+        <li option="3">Option 3</li>
+      </ul>
+    </amp-react-selector>
 
     <div style="height: 500vh">scroll down...</div>
 

--- a/src/amp-react-selector.js
+++ b/src/amp-react-selector.js
@@ -18,6 +18,7 @@ import ReactCompatibleBaseElement from './react-compat-base-element.js';
 import {
   AmpContext,
 } from './amp-context.js';
+import {Slot} from './slot.js';
 
 const {
   useContext,
@@ -77,7 +78,7 @@ AmpSelector.Option = function(props) {
     return props.render(optionProps);
   }
   return preact.createElement(
-    props.tagName || 'div',
+    props.type || props.tagName || 'div',
     optionProps,
     props.children);
 }
@@ -116,15 +117,10 @@ const AmpReactSelector = ReactCompatibleBaseElement(AmpSelector, {
         const option = child.getAttribute('option');
         const props = {
           option,
-          render: props => {
-            // TBD: This is sort of similar to our Slot logic.
-            if (props.selected) {
-              child.setAttribute('selected', '');
-            } else {
-              child.removeAttribute('selected');
-            }
-            child.onclick = props.onClick;
-
+          type: Slot,
+          retarget: true,
+          assignedElements: [child],
+          postRender: () => {
             // Skip mutations to avoid cycles.
             mu.takeRecords();
           },
@@ -138,7 +134,9 @@ const AmpReactSelector = ReactCompatibleBaseElement(AmpSelector, {
       reactBaseElement.mutateProps({defaultValue: value, children});
     };
     mu.observe(element, {attributeFilter: ['option', 'selected'], subtree: true});
-    setTimeout(rebuild);
+
+    // Run the first build.
+    rebuild();
   },
 });
 customElements.define('amp-react-selector', AmpReactSelector);

--- a/src/amp-react-selector.js
+++ b/src/amp-react-selector.js
@@ -52,14 +52,14 @@ export function AmpSelector(props) {
     preact.createElement(
       AmpSelectorContext.Provider,
       {
-        ...props,
         value: {
           multiple,
           // TBD: controlled values require override of properties.
           selected: value ? [].concat(value) : selected,
           setSelected: setSelectedRef.current,
         },
-      }
+      },
+      props.children
     )
   );
 }

--- a/src/amp-react-selector.js
+++ b/src/amp-react-selector.js
@@ -130,12 +130,17 @@ const AmpReactSelector = ReactCompatibleBaseElement(AmpSelector, {
         children.push(preact.createElement(AmpSelector.Option, props));
       });
 
-      reactBaseElement.mutateProps({defaultValue: value, children});
+      reactBaseElement.mutateProps({value, children});
     };
     mu.observe(element, {attributeFilter: ['option', 'selected'], subtree: true});
 
     // Run the first build.
     rebuild();
+    reactBaseElement.mutateProps({
+      onChange: event => {
+        reactBaseElement.mutateProps({value: event.target.value});
+      },
+    });
   },
 });
 customElements.define('amp-react-selector', AmpReactSelector);

--- a/src/amp-react-selector.js
+++ b/src/amp-react-selector.js
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2019 The AMP HTML Authors. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS-IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import ReactCompatibleBaseElement from './react-compat-base-element.js';
+import {
+  AmpContext,
+} from './amp-context.js';
+
+const {
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+} = preactHooks;
+
+const LINE_HEIGHT_EM = 1.15;
+
+
+export function AmpSelector(props) {
+  return preact.createElement('div', {
+    ...props,
+  }, props.children);
+}
+
+
+AmpSelector.Option = function(props) {
+  // QQQQ: Context
+  useEffect(() => {
+
+  });
+  return props.render({
+    option: props.option,
+    selected: props.selected || false,
+  });
+}
+
+
+const AmpReactSelector = ReactCompatibleBaseElement(AmpSelector, {
+  className: 'i-amphtml-fill-content i-amphtml-replaced-content',
+  attrs: {
+  },
+  children: {
+    'children': '*',
+  },
+});
+customElements.define('amp-react-selector', AmpReactSelector);

--- a/src/react-compat-base-element.js
+++ b/src/react-compat-base-element.js
@@ -174,7 +174,8 @@ export default function ReactCompatibleBaseElement(Component, opts) {
     rerender_() {
       if (!this.container_) {
         // TBD: create container/shadow in the amp-element.js?
-        this.container_ = this.getWin().document.createElement('i-amphtml-c');
+        this.container_ = this.getWin().document.createElement(
+          opts.template ? 'template' : 'i-amphtml-c');
         // TBD: we want `position:absolute` in a few layouts only.
         this.container_.style.display = 'block';
         this.container_.style.position = 'absolute';
@@ -184,7 +185,14 @@ export default function ReactCompatibleBaseElement(Component, opts) {
         this.container_.style.bottom = '0';
         this.customProps_.style = {width: '100%', height: '100%'};
         if (opts.template) {
-          // Do not attach container. It will be used as a fragment.
+          // Do not attach container. It will be used as a disconnected
+          // fragment, never attached to DOM. This mode is useful for more
+          // in-depth DOM mapping where simple SD slot distribution is not
+          // applicable because of SD limitations. For instance, a
+          // `amp-selector > ul > li[option]` structure where `li` is a mapped
+          // child, separated from the `amp-selector` by a necessary `ul`
+          // intermediary. The `li[option]` is, conceptually, still a mapped
+          // slot, but SD does not allow distribution of nested children.
         } else if (opts.children || opts.passthrough) {
           const shadowRoot = this.element.attachShadow({mode: 'open'});
           const sizerSlot = this.getWin().document.createElement('slot');

--- a/src/react-compat-base-element.js
+++ b/src/react-compat-base-element.js
@@ -183,7 +183,9 @@ export default function ReactCompatibleBaseElement(Component, opts) {
         this.container_.style.right = '0';
         this.container_.style.bottom = '0';
         this.customProps_.style = {width: '100%', height: '100%'};
-        if (opts.children || opts.passthrough) {
+        if (opts.template) {
+          // Do not attach container. It will be used as a fragment.
+        } else if (opts.children || opts.passthrough) {
           const shadowRoot = this.element.attachShadow({mode: 'open'});
           const sizerSlot = this.getWin().document.createElement('slot');
           sizerSlot.setAttribute('name', 'i-amphtml-sizer');

--- a/src/slot.js
+++ b/src/slot.js
@@ -52,6 +52,14 @@ export function Slot(props) {
     const assignedElements = getAssignedElements(props, slot);
     slot.__assignedElements = assignedElements;
 
+    // TBD: Just for debug for now. but maybe can also be used for hydration?
+    slot.setAttribute('i-amphtml-context', JSON.stringify(context));
+    // TODO: remove debug info.
+    assignedElements.forEach(node => {
+      node.__assignedSlot = slot;
+      node.setAttribute('i-amphtml-context', JSON.stringify(context));
+    });
+
     // Retarget slots and content.
     if (props.retarget) {
       // TBD: retargetting here is for:
@@ -93,7 +101,6 @@ export function Slot(props) {
           });
         }
       });
-
     }
 
     const oldContext = slot['i-amphtml-context'];
@@ -102,6 +109,7 @@ export function Slot(props) {
       // TODO: Switch to fast child-node discover. See Revamp for the algo.
       const affectedNodes = [];
       assignedElements.forEach(node => {
+        node['i-amphtml-context'] = context;
         affectedNodes.push(...getAmpElements(node));
       });
       affectedNodes.forEach(node => {
@@ -142,8 +150,6 @@ export function Slot(props) {
     };
   });
 
-  // TBD: Just for debug for now. but maybe can also be used for hydration?
-  slotProps['i-amphtml-context'] = JSON.stringify(context);
   return preact.createElement('slot', slotProps);
 }
 

--- a/src/slot.js
+++ b/src/slot.js
@@ -182,8 +182,8 @@ function getAssignedElements(props, slotElement) {
 
 function toggleAttribute(element, attr, on) {
   if (on) {
-    element.setAttribute('selected', '');
+    element.setAttribute(attr, '');
   } else {
-    element.removeAttribute('selected');
+    element.removeAttribute(attr);
   }
 }


### PR DESCRIPTION
amp-selector is the most unusual component so far.

The top level API (`value` property, `onChange`, etc) are modeled on React's support for `<select>`.

Next, in AMP we allow a mostly free-form structure of amp-selector content as long as there are some elements that have `option` attribute. This is done to easily support `ul > li`, `table > tr > td`, and similar structures. Thus, the SD slots do not work here. Instead I adopted a different structure: `AmpSelector > whatever > AmpSelector.Option` connected via `AmpSelectorContext`. `AmpSelectorContext` is private and otherwise not visible to the outside API.

Finally, AMP side is unusual too: we have to observe subtree mutations to find `[option]` deep-children. And w/o slots we use the Preact's render function to keep DOM and VDOM in-sync.